### PR TITLE
Student 12, ENH make count_substring case insensitive

### DIFF
--- a/bootcamp_module08/core/student_12.py
+++ b/bootcamp_module08/core/student_12.py
@@ -24,7 +24,7 @@ def count_substring(string, substring):
         left_bound = i
         right_bound = i + substring_length
         candidate_substring = string[left_bound:right_bound]
-        if candidate_substring == substring:
+        if candidate_substring.lower() == substring.lower():
             count += 1
 
     return count

--- a/bootcamp_module08/core/student_12.py
+++ b/bootcamp_module08/core/student_12.py
@@ -16,6 +16,9 @@ def count_substring(string, substring):
     """
     count = 0
 
+    string = string.lower()
+    substring = substring.lower()
+
     string_length = len(string)
     substring_length = len(substring)
     n_subsequences = string_length - substring_length + 1
@@ -24,7 +27,7 @@ def count_substring(string, substring):
         left_bound = i
         right_bound = i + substring_length
         candidate_substring = string[left_bound:right_bound]
-        if candidate_substring.lower() == substring.lower():
+        if candidate_substring == substring:
             count += 1
 
     return count

--- a/bootcamp_module08/core/tests/test_student_12.py
+++ b/bootcamp_module08/core/tests/test_student_12.py
@@ -10,6 +10,33 @@ def test_count_substring_single():
     assert expected_count == observed_count
 
 
+def test_count_substring_single_case_insensitive1():
+    test_string = "CGCTaGCGT"
+    test_substring = "TAG"
+
+    expected_count = 1
+    observed_count = count_substring(test_string, test_substring)
+    assert expected_count == observed_count
+
+
+def test_count_substring_single_case_insensitive2():
+    test_string = "CGCTAGCgT"
+    test_substring = "TAG"
+
+    expected_count = 1
+    observed_count = count_substring(test_string, test_substring)
+    assert expected_count == observed_count
+
+
+def test_count_substring_single_case_insensitive3():
+    test_string = "CGCTaGCgT"
+    test_substring = "TAG"
+
+    expected_count = 1
+    observed_count = count_substring(test_string, test_substring)
+    assert expected_count == observed_count
+
+
 def test_count_substring_repeated():
     test_string = "AGCTAGCAGT"
     test_substring = "AGC"
@@ -19,8 +46,53 @@ def test_count_substring_repeated():
     assert expected_count == observed_count
 
 
+def test_count_substring_repeated_case_insensitive1():
+    test_string = "AGCTaGCAGT"
+    test_substring = "AGC"
+
+    expected_count = 2
+    observed_count = count_substring(test_string, test_substring)
+    assert expected_count == observed_count
+
+
+def test_count_substring_repeated_case_insensitive2():
+    test_string = "AgCTaGCAGT"
+    test_substring = "AGC"
+
+    expected_count = 2
+    observed_count = count_substring(test_string, test_substring)
+    assert expected_count == observed_count
+
+
+def test_count_substring_repeated_case_insensitive3():
+    test_string = "AGCtAGCAGT"
+    test_substring = "AGC"
+
+    expected_count = 2
+    observed_count = count_substring(test_string, test_substring)
+    assert expected_count == observed_count
+
+
 def test_count_substring_none():
     test_string = "AGTCCCCTAGA"
+    test_substring = "AAA"
+
+    expected_count = 0
+    observed_count = count_substring(test_string, test_substring)
+    assert expected_count == observed_count
+
+
+def test_count_substring_none_case_insensitive1():
+    test_string = "AGTCcCCTAGA"
+    test_substring = "AAA"
+
+    expected_count = 0
+    observed_count = count_substring(test_string, test_substring)
+    assert expected_count == observed_count
+
+
+def test_count_substring_none_case_insensitive2():
+    test_string = "agtcccctaga"
     test_substring = "AAA"
 
     expected_count = 0


### PR DESCRIPTION
Make count_substring case insensitive, so that it will work for `'acgt' == 'ACGT', == 'aCgT'`

Student ID 12